### PR TITLE
Update adaptec-raid.sh

### DIFF
--- a/adaptec-raid.sh
+++ b/adaptec-raid.sh
@@ -83,7 +83,7 @@ LLDLogicalDrives() {
     do
 	ld_count=$($cli GETCONFIG $i AD | grep "Logical devices/Failed/Degraded" | cut -f2 -d":" | cut -f1 -d"/" | sed -e 's/^ //' )
 	
-	ld_ids=$($cli GETCONFIG $i LD | grep "Logical device number " | cut -f4 -d" " | sed -e 's/^ //' )
+	ld_ids=$($cli GETCONFIG $i LD | grep -i "Logical device number " | cut -f4 -d" " | sed -e 's/^ //' )
 	
 	for ld_id in $ld_ids; do
 	    ld_name=$($cli GETCONFIG $i LD $ld_id | grep "Logical device name" | cut -f2 -d":" | sed -e 's/^ //' )


### PR DESCRIPTION
fix output info Logical device number
test:
| UCLI |  Microsemi Adaptec uniform command line interface
| UCLI |  Version 3.07.00 (23850)
sudo /usr/local/sbin/arcconf GETCONFIG 1 LD | grep -i "Logical device number"
Logical Device number 0